### PR TITLE
fix bug with mac apostrophe/geresh not being recognized

### DIFF
--- a/src/components/HebrewTouchTyping/HebrewTouchTyping.tsx
+++ b/src/components/HebrewTouchTyping/HebrewTouchTyping.tsx
@@ -9,6 +9,7 @@ import HeroSection from '../HeroSection/HeroSection';
 import {useWPM} from '../../utils/useWPM';
 import {KeyboardSvg} from '../KeyboardSvg/KeyboardSvg';
 import {useUserDataContext} from '../UserDataProvider/UserDataProvider';
+import {normalizeGeresh} from '../../utils/normalizeGeresh';
 
 interface HebrewTouchTypingProps {
   className?: string;
@@ -57,7 +58,8 @@ const HebrewTouchTyping = ({
         return;
       }
 
-      setInputValue(newText);
+      const normalizedText = normalizeGeresh(newText);
+      setInputValue(normalizedText);
       if (newText.length === text.length) {
         onExerciseCompleted();
       }

--- a/src/components/HebrewTouchTyping/__tests__/HebrewTouchTyping.driver.tsx
+++ b/src/components/HebrewTouchTyping/__tests__/HebrewTouchTyping.driver.tsx
@@ -21,8 +21,10 @@ export type HebrewTouchTypingDriver = {
     currentLetter: () => HTMLElement | null;
   };
 };
-export const getDriver = (): HebrewTouchTypingDriver => {
-  const initialExercise: LettersExercise = {
+export const getDriver = (
+  manualInitialExercise?: LettersExercise,
+): HebrewTouchTypingDriver => {
+  const initialExercise: LettersExercise = manualInitialExercise ?? {
     index: 0,
     type: ExerciseType.REVIEW,
     text: ['שורה 1 ', 'שורה 2'],

--- a/src/components/HebrewTouchTyping/__tests__/HebrewTouchTyping.spec.tsx
+++ b/src/components/HebrewTouchTyping/__tests__/HebrewTouchTyping.spec.tsx
@@ -1,5 +1,9 @@
 import {cleanup, screen, waitFor} from '@testing-library/react';
-import {getListOfTextExercises} from '../../../utils/generateLetterExercises';
+import {ExerciseType} from '../../../constants/practiceAndReviewLetterSets';
+import {
+  getListOfTextExercises,
+  LettersExercise,
+} from '../../../utils/generateLetterExercises';
 import {getDriver} from './HebrewTouchTyping.driver';
 
 let driver: ReturnType<typeof getDriver>;
@@ -72,6 +76,54 @@ describe('text transform', () => {
     expect(incorrectLetterelements).toHaveLength(1);
   });
 
+  it("should apply correct letter class when typing ' in exercise expecting ' (Windows default)", async () => {
+    const exercise: LettersExercise = {
+      index: 0,
+      type: ExerciseType.REVIEW,
+      text: ["'", 'ם'],
+      newLetters: ["'", 'ם'],
+    };
+
+    driver = getDriver(exercise);
+
+    driver.when.render();
+
+    driver.when.textIsTyped("'");
+
+    const letterElements = driver.get.statelessLetters();
+    expect(letterElements).toHaveLength(driver.get.textLength() - 2);
+
+    const correctLetterElements = await driver.get.correctLetters();
+    expect(correctLetterElements).toHaveLength(1);
+
+    const incorrectLetterElements = driver.get.incorrectLetters();
+    expect(incorrectLetterElements).toHaveLength(0);
+  });
+
+  it("should apply correct letter class when typing ׳ in exercise expecting ' (Mac default)", async () => {
+    const exercise: LettersExercise = {
+      index: 0,
+      type: ExerciseType.REVIEW,
+      text: ["'", 'ם'],
+      newLetters: ["'", 'ם'],
+    };
+
+    driver = getDriver(exercise);
+
+    driver.when.render();
+
+    driver.when.textIsTyped('׳');
+
+    const letterElements = driver.get.statelessLetters();
+    expect(letterElements).toHaveLength(driver.get.textLength() - 2);
+
+    const correctLetterElements = await driver.get.correctLetters();
+    expect(correctLetterElements).toHaveLength(1);
+
+    const incorrectLetterElements = driver.get.incorrectLetters();
+    expect(incorrectLetterElements).toHaveLength(0);
+  });
+
   it('should mark lesson as complete when all text has been typed', async () => {
     driver.when.render();
     expect(screen.queryByText(/exercise complete!/i)).not.toBeInTheDocument();
@@ -111,6 +163,7 @@ describe('text transform', () => {
     driver.when.render();
 
     driver.when.exerciseIsSelected(`${textExercises[0].index}`);
+
     expect(screen.getAllByText(textExercises[0].label)).toHaveLength(2);
   });
 });

--- a/src/constants/hebrewLetters.ts
+++ b/src/constants/hebrewLetters.ts
@@ -27,3 +27,6 @@ export const HEBREW_LETTERS = [
   'ש',
   'ת',
 ];
+
+export const WINDOWS_GERESH = "'";
+export const MAC_GERESH = '׳';

--- a/src/utils/__tests__/normalizeGeresh.spec.ts
+++ b/src/utils/__tests__/normalizeGeresh.spec.ts
@@ -1,0 +1,10 @@
+import {normalizeGeresh} from '../normalizeGeresh';
+
+it.each([
+  ['׳', "'"],
+  ["'", "'"],
+  ["ק׳ץ", "ק'ץ"],
+  ["ק'ץ", "ק'ץ"],
+])("converts %s to %s", (input, expectedOutput) => {
+  expect(normalizeGeresh(input)).toEqual(expectedOutput);
+});

--- a/src/utils/normalizeGeresh.ts
+++ b/src/utils/normalizeGeresh.ts
@@ -1,0 +1,9 @@
+import {MAC_GERESH, WINDOWS_GERESH} from '../constants/hebrewLetters';
+
+/**
+ * Function to normalize differences between geresh (Hebrew apostrophe)
+ * when typed on Windows "'" vs Mac "׳"
+ */
+export function normalizeGeresh(input: string): string {
+  return input.replace(new RegExp(MAC_GERESH, 'g'), WINDOWS_GERESH);
+}


### PR DESCRIPTION
macOS outputs ׳ when you type the key for geresh (W on QWERTY), but Windows outputs a normal apostrophe, i.e., '

This PR normalizes both to the apostrophe ', which is the unicode character used in the tests.