### PR TITLE
add useEffect to force focus on exercise change

### DIFF
--- a/src/components/HebrewTouchTyping/HebrewTouchTyping.tsx
+++ b/src/components/HebrewTouchTyping/HebrewTouchTyping.tsx
@@ -37,6 +37,7 @@ const HebrewTouchTyping = ({
     setInputValue('');
     setIsExerciseComplete(false);
     resetWPM();
+    inputRef.current?.focus();
   }, [resetWPM, selectedExercise]);
 
   const onExerciseCompleted = useCallback(() => {


### PR DESCRIPTION
This fixes a bug in firefox where switching exercises causes the app to stop responding to keyboard input. The problem comes from how firefox handles 'autofocus'

https://stackoverflow.com/questions/9955398/autofocus-attribute-of-html5-does-not-work-only-in-firefox-when-forminput-ar

This works around that using javascript (same as what is already in the app for onBlur events)